### PR TITLE
Publish package on github actions and let consumer handle debounce

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,10 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
-
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          registry: 'https://npm.pkg.github.com'
   release:
     runs-on: ubuntu-latest
     needs: publish

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ function install (Vue, opts) {
     prevent: ['input', 'textarea']
   }
   const options = { ...defaultOptions, ...opts }
-  const lock = new Map()
 
   const vueHotKey = {
     register (key, fn, hotkeysOpts) {
@@ -38,15 +37,7 @@ function install (Vue, opts) {
         if (options.prevent.includes(element)) {
           return
         }
-
-        if (lock.get(key)) {
-          return
-        }
-
-        lock.set(key, true)
-
         fn(event, handler)
-        setTimeout(() => lock.set(key, false), 500)
       })
     },
     unregister (key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@estrategiahq/vue-hotkey",
-  "version": "0.0.3",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@estrategiahq/vue-hotkey",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Simple Vue hotkeys",
   "main": "dist/main.js",
   "repository": {


### PR DESCRIPTION
Published package for internal use on github packages.
Remove lock on key event, to allow "double press" hotkeys. 